### PR TITLE
Sequence names are corrected for alignments for develop branch

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -94,6 +94,7 @@ data/fasta-input.fasta
 data/fasta-input2.fasta
 data/fasta-input_double_id.fasta
 data/fasta-input3.fasta
+data/fasta-input4.fasta
 
 data/test.gb
 data/test.tsv
@@ -107,6 +108,7 @@ data/single_genome.yml
 data/two_genomes_nonuniq_names.yml
 data/two_genomes_uniq_names.yml
 data/two_genomes_forbidden_names.yml
+data/two_genomes_long_names.yml
 
 ### Vector set
 data/vectors/M13mp18.fasta

--- a/MANIFEST
+++ b/MANIFEST
@@ -93,6 +93,7 @@ data/existing_testfile
 data/fasta-input.fasta
 data/fasta-input2.fasta
 data/fasta-input_double_id.fasta
+data/fasta-input3.fasta
 
 data/test.gb
 data/test.tsv
@@ -105,6 +106,7 @@ data/multiple_trees.newick
 data/single_genome.yml
 data/two_genomes_nonuniq_names.yml
 data/two_genomes_uniq_names.yml
+data/two_genomes_forbidden_names.yml
 
 ### Vector set
 data/vectors/M13mp18.fasta

--- a/data/fasta-input3.fasta
+++ b/data/fasta-input3.fasta
@@ -1,0 +1,5 @@
+>Test2|
+ACGTTGCGTG
+>Test3 more details
+ACGT
+TGCGT

--- a/data/fasta-input3.fasta
+++ b/data/fasta-input3.fasta
@@ -1,5 +1,5 @@
 >Test2|
 ACGTTGCGTG
->Test3 more details
+>Test3
 ACGT
 TGCGT

--- a/data/fasta-input4.fasta
+++ b/data/fasta-input4.fasta
@@ -1,0 +1,5 @@
+>Test2
+ACGTTGCGTG
+>Test3_long_sequence_name
+ACGT
+TGCGT

--- a/data/two_genomes_forbidden_names.yml
+++ b/data/two_genomes_forbidden_names.yml
@@ -1,0 +1,11 @@
+---
+genomes: 
+   -
+    name: Test_genome_1
+    sequence_files:
+      - data/fasta-input.fasta
+   -
+    name: Test_genome_2
+    sequence_files:
+      - data/fasta-input3.fasta
+

--- a/data/two_genomes_long_names.yml
+++ b/data/two_genomes_long_names.yml
@@ -1,0 +1,11 @@
+---
+genomes: 
+   -
+    name: Test_genome_1
+    sequence_files:
+      - data/fasta-input.fasta
+   -
+    name: Test_genome_2
+    sequence_files:
+      - data/fasta-input4.fasta
+

--- a/lib/AliTV.pm
+++ b/lib/AliTV.pm
@@ -401,8 +401,13 @@ sub _make_and_set_uniq_seq_names
     }
 
     # if the number of keys is equal to the number of total sequences,
-    # they should be uniq
-    if ((keys %seen) == @all_seq_ids)
+    # they should be uniq, but we need to guarantee, that the name
+    # contains only alphanumeric or "word" characters
+    if (
+	((keys %seen) == @all_seq_ids)
+	&&
+	((grep {$_->{name} =~ /\W/} @all_seq_ids) == 0)
+	)
     {
 	# sequence names are uniq and can be used as uniq names
 	@all_seq_ids = map { {name => $_->{name}, genome => $_->{genome}, uniq_name => $_->{name}} } (@all_seq_ids);

--- a/lib/AliTV.pm
+++ b/lib/AliTV.pm
@@ -402,11 +402,14 @@ sub _make_and_set_uniq_seq_names
 
     # if the number of keys is equal to the number of total sequences,
     # they should be uniq, but we need to guarantee, that the name
-    # contains only alphanumeric or "word" characters
+    # contains only alphanumeric or "word" characters and that the
+    # name is not longer than 8 characters
     if (
 	((keys %seen) == @all_seq_ids)
 	&&
 	((grep {$_->{name} =~ /\W/} @all_seq_ids) == 0)
+	&&
+	((grep {length($_->{name}) > 8} @all_seq_ids) == 0)
 	)
     {
 	# sequence names are uniq and can be used as uniq names

--- a/lib/AliTV/Base/Version.pm
+++ b/lib/AliTV/Base/Version.pm
@@ -4,7 +4,7 @@ use 5.010000;
 #use strict;
 #use warnings;
 
-use version 0.77; our $VERSION = version->declare("v0.1.5");
+use version 0.77; our $VERSION = version->declare("v0.1.6");
 
 # The following code is from Bio::Root::Version module and try to
 # handle multiple levels of inheritance and is adopted to work on

--- a/t/515_AliTV-_make_and_set_uniq_seq_names.t
+++ b/t/515_AliTV-_make_and_set_uniq_seq_names.t
@@ -50,6 +50,18 @@ $got = get_sequence_ids($obj);
 
 is_deeply($got, $expected, 'Forbidden sequence names are changed');
 
+# Two genomes with sequence names being longer than 8 characters
+my $two_genomes_long_names = 'data/two_genomes_long_names.yml';
+$obj = new_ok('AliTV', ["-file" => $two_genomes_long_names]);
+$obj->_import_genomes();
+
+$obj->_make_and_set_uniq_seq_names();
+
+$expected = [sort ("seq0", "seq1", "seq2")];
+$got = get_sequence_ids($obj);
+
+is_deeply($got, $expected, 'Long sequence names are changed');
+
 done_testing;
 
 sub get_sequence_ids

--- a/t/515_AliTV-_make_and_set_uniq_seq_names.t
+++ b/t/515_AliTV-_make_and_set_uniq_seq_names.t
@@ -38,6 +38,18 @@ $got = get_sequence_ids($obj);
 
 is_deeply($got, $expected, 'Non-unique sequences names are changed');
 
+# Two genomes with sequence names containing non "word" characters
+my $two_genomes_forbidden_names = 'data/two_genomes_forbidden_names.yml';
+$obj = new_ok('AliTV', ["-file" => $two_genomes_forbidden_names]);
+$obj->_import_genomes();
+
+$obj->_make_and_set_uniq_seq_names();
+
+$expected = [sort ("seq0", "seq1", "seq2")];
+$got = get_sequence_ids($obj);
+
+is_deeply($got, $expected, 'Forbidden sequence names are changed');
+
 done_testing;
 
 sub get_sequence_ids


### PR DESCRIPTION
To keep the origin sequence names, we need fulfil two criteria:

sequence names are 8 characters at maximum
sequence names contain only word characters
Otherwise, the sequences will be renamed.

This will guarantee, that no forbidden character inside the sequence name will crash the alignment programs.
