### PR TITLE
No color gradient for genomes

### DIFF
--- a/lib/AliTV.pm
+++ b/lib/AliTV.pm
@@ -175,7 +175,7 @@ sub get_json
 	    'drawAllLinks' => JSON::false,
 	    'endLineColor' => '#1d91c0',
 	    'hideHalfVisibleLinks' => JSON::false,
-	    'startLineColor' => '#49006a'
+	    'startLineColor' => '#1d91c0'
 	},
 
 	'maxLinkIdentity' => 100,

--- a/lib/AliTV/Base/Version.pm
+++ b/lib/AliTV/Base/Version.pm
@@ -4,7 +4,7 @@ use 5.010000;
 #use strict;
 #use warnings;
 
-use version 0.77; our $VERSION = version->declare("v0.1.7");
+use version 0.77; our $VERSION = version->declare("v0.1.8");
 
 # The following code is from Bio::Root::Version module and try to
 # handle multiple levels of inheritance and is adopted to work on


### PR DESCRIPTION
The default json file now disables rainbow colors for the different genomes.
