### PR TITLE
Fixing tree issues

### DIFF
--- a/lib/AliTV.pm
+++ b/lib/AliTV.pm
@@ -101,6 +101,7 @@ sub run
     if (exists $self->{_yml_import}{tree} && defined $self->{_yml_import}{tree})
     {
 	my $tree_obj = AliTV::Tree->new(-file => ($self->{_yml_import}{tree}));
+	$tree_obj->balance_node_depth();
 	$self->{_tree} = $tree_obj->tree_2_json_structure();
     }
 

--- a/lib/AliTV.pm
+++ b/lib/AliTV.pm
@@ -104,6 +104,9 @@ sub run
 	$tree_obj->ladderize();
 	$tree_obj->balance_node_depth();
 	$self->{_tree} = $tree_obj->tree_2_json_structure();
+
+	# store the order
+	$self->{_tree_genome_order} = $tree_obj->get_genome_order();
     }
 
     my $json_text = $self->get_json();

--- a/lib/AliTV.pm
+++ b/lib/AliTV.pm
@@ -268,10 +268,16 @@ sub get_json
     $data{filters}{karyo}{order} = \@chromosomelist_sorted;
 
     # need to define a genome order
-    # easy to implement: alphabetically sorted
-    my %genomes = map { $data{data}{karyo}{chromosomes}{$_}{genome_id} => 1 } (keys %{$data{data}{karyo}{chromosomes}});
-    $data{filters}{karyo}{genome_order} = [sort keys %genomes];
-
+    # easy to implement: alphabetically sorted or if a tree exists use the order from the tree
+    if (exists $self->{_tree_genome_order})
+    {
+	# ordered by the tree
+	$data{filters}{karyo}{genome_order} = $self->{_tree_genome_order};
+    } else {
+	# alphabetically sorted
+	my %genomes = map { $data{data}{karyo}{chromosomes}{$_}{genome_id} => 1 } (keys %{$data{data}{karyo}{chromosomes}});
+	$data{filters}{karyo}{genome_order} = [sort keys %genomes];
+    }
     return to_json(\%data);
 }
 

--- a/lib/AliTV.pm
+++ b/lib/AliTV.pm
@@ -101,6 +101,7 @@ sub run
     if (exists $self->{_yml_import}{tree} && defined $self->{_yml_import}{tree})
     {
 	my $tree_obj = AliTV::Tree->new(-file => ($self->{_yml_import}{tree}));
+	$tree_obj->ladderize();
 	$tree_obj->balance_node_depth();
 	$self->{_tree} = $tree_obj->tree_2_json_structure();
     }

--- a/lib/AliTV/Base/Version.pm
+++ b/lib/AliTV/Base/Version.pm
@@ -4,7 +4,7 @@ use 5.010000;
 #use strict;
 #use warnings;
 
-use version 0.77; our $VERSION = version->declare("v0.1.12");
+use version 0.77; our $VERSION = version->declare("v0.1.13");
 
 # The following code is from Bio::Root::Version module and try to
 # handle multiple levels of inheritance and is adopted to work on

--- a/lib/AliTV/Tree.pm
+++ b/lib/AliTV/Tree.pm
@@ -90,7 +90,7 @@ sub _deep_scan
     if($node->is_Leaf())
     {
 	# we are done --> return a hash ref
-	$return_value = { name => $node->id() };
+	$return_value = {children => [ { name => $node->id() } ] };
     } else {
 	# we have no leaf node, therefore
 	# get a list of all descendents

--- a/lib/AliTV/Tree.pm
+++ b/lib/AliTV/Tree.pm
@@ -173,6 +173,12 @@ sub balance_node_depth
 
 }
 
+sub _ladderize
+{
+    my $self = shift;
+
+}
+
 sub check_4_leaf_nodes
 {
     my $self = shift;

--- a/lib/AliTV/Tree.pm
+++ b/lib/AliTV/Tree.pm
@@ -173,11 +173,80 @@ sub balance_node_depth
 
 }
 
+sub ladderize
+{
+    my $self = shift;
+
+    $self->_ladderize(1);
+}
+
 sub _ladderize
 {
     my $self = shift;
 
+    my ($up) = @_;
+
+    $self->_make_tree_copy();
+
+    my $tree = $self->{_orig_tree};
+
+    # get the root node
+    my $root_old = $tree->get_root_node();
+    my $root_new;
+
+    if ($root_old->id())
+    {
+	$root_new = Bio::Tree::Node->new(-id => $root_old->id());
+    } else {
+	$root_new = Bio::Tree::Node->new();
+    }
+
+    _order_nodes($root_old, $root_new, $up);
+
+    # create a new tree
+    my $new_tree = Bio::Tree::Tree->new(-root => $root_new);
+
+    $self->{_orig_tree} = $new_tree;
+
 }
+
+sub _order_nodes
+{
+    my ($old, $new, $up) = @_;
+
+    if ($old->is_Leaf())
+    {
+	return $old;
+    } else {
+	my @descendents = $old->each_Descendent();
+
+	# sort the descendents by their descendent_count
+	@descendents = sort {$a->descendent_count() <=> $b->descendent_count() || $a->id() cmp $b->id() || $a->internal_id() <=> $b->internal_id() } (@descendents);
+
+	unless (defined $up && $up)
+	{
+	    @descendents = reverse @descendents;
+	}
+
+	# call order_nodes for each node and delete the node afterwards
+	foreach my $curr_node (@descendents)
+	{
+	    my $node_new;
+	    if ($curr_node->id())
+	    {
+		$node_new = Bio::Tree::Node->new(-id => $curr_node->id());
+	    } else {
+		$node_new = Bio::Tree::Node->new();
+	    }
+
+	    $new->add_Descendent($node_new);
+
+	    _order_nodes($curr_node, $node_new, $up);
+	}
+    }
+}
+
+
 
 sub check_4_leaf_nodes
 {

--- a/lib/AliTV/Tree.pm
+++ b/lib/AliTV/Tree.pm
@@ -249,6 +249,10 @@ sub _order_nodes
 sub get_genome_order
 {
     my $self = shift;
+
+    my $tree = $self->{_orig_tree};
+
+    return [map {$_->id()} $tree->get_leaf_nodes()];
 }
 
 sub check_4_leaf_nodes

--- a/lib/AliTV/Tree.pm
+++ b/lib/AliTV/Tree.pm
@@ -246,7 +246,10 @@ sub _order_nodes
     }
 }
 
-
+sub get_genome_order
+{
+    my $self = shift;
+}
 
 sub check_4_leaf_nodes
 {

--- a/t/112_AliTV-Tree-tree_2_json_structure.t
+++ b/t/112_AliTV-Tree-tree_2_json_structure.t
@@ -29,6 +29,6 @@ foreach my $inputfile ( keys %expected ) {
 done_testing;
 
 __DATA__
-data/tree_a.newick { children => [ { name => 'a' }, { children => [ { name => 'b' }, { children => [ {name => 'c' }, { name => 'd' } ] } ] } ] }
-data/tree_b.newick { children => [ { children => [ { name => 'a' }, { name => 'b' } ] }, { children => [ {name => 'c' }, { name => 'd' } ] } ] }
-data/tree_c.newick { children => [ { name => 'a' }, { children => [ { name => 'b' }, { children => [ {name => 'c' }, { children => [ { name => 'd' }, { children => [ { name => 'e' }, { children => [ { name => 'f' }, { name => 'g' } ] } ] } ] } ] } ] } ] } 
+data/tree_a.newick { children => [ { children => [ { name => 'a' } ] }, { children => [ { children => [ { name => 'b' } ] }, { children => [ { children => [ {name => 'c' } ] }, { children => [ { name => 'd' } ] } ] } ] } ] }
+data/tree_b.newick { children => [ { children => [ { children => [ { name => 'a' } ] }, { children => [ { name => 'b' } ] } ] }, { children => [ { children => [ {name => 'c' } ] }, { children => [ { name => 'd' } ] } ] } ] }
+data/tree_c.newick { children => [ { children => [ { name => 'a' } ] }, { children => [ { children => [ { name => 'b' } ]}, { children => [ { children => [ {name => 'c' } ] }, { children => [ { children => [ { name => 'd' } ] }, { children => [ { children => [ { name => 'e' } ] }, { children => [ { children => [ { name => 'f' } ] }, { children => [ { name => 'g' } ] } ] } ] } ] } ] } ] } ] }

--- a/t/113_AliTV-Tree-balance_node_depth.t
+++ b/t/113_AliTV-Tree-balance_node_depth.t
@@ -63,3 +63,5 @@ done_testing;
 
 __DATA__
 data/tree_a.newick
+data/tree_b.newick
+data/tree_c.newick

--- a/t/113_AliTV-Tree-balance_node_depth.t
+++ b/t/113_AliTV-Tree-balance_node_depth.t
@@ -18,44 +18,49 @@ chomp(@inputfiles);
 
 # test if the topology of the tree is valid, if qdist is available
 my $qdist_executable = which('qdist');
-my $num_tests = @inputfiles;
+my $num_tests        = @inputfiles;
 SKIP: {
-    skip "Missing qdist program to calculate quartest distance of trees", $num_tests unless ($qdist_executable);
+    skip "Missing qdist program to calculate quartest distance of trees",
+      $num_tests
+      unless ($qdist_executable);
 
-    foreach my $inputfile ( @inputfiles ) {
+    foreach my $inputfile (@inputfiles) {
+
         # generate a temporary files
-        my ($fh, $tree_file) = File::Temp::tempfile();
+        my ( $fh, $tree_file ) = File::Temp::tempfile();
 
         $obj->file($inputfile);
         $obj->balance_node_depth();
 
-	my $tree = $obj->{_tree};
+        my $tree = $obj->{_tree};
 
-	print $fh $tree->as_text('newick');
+        print $fh $tree->as_text('newick');
 
-	my $cmd = join(" ", ($qdist_executable, $inputfile, $tree_file));
+        my $cmd = join( " ", ( $qdist_executable, $inputfile, $tree_file ) );
 
-	my $result = qx($cmd);
+        my $result = qx($cmd);
 
-	# check if result contains zeros for the distances:
-	# data/tree_a.newick : 0 0
-	#    /tmp/e3HIyEiRSF : 0 0
+        # check if result contains zeros for the distances:
+        # data/tree_a.newick : 0 0
+        #    /tmp/e3HIyEiRSF : 0 0
 
-	# delete filenames
-	$result =~ s/^[^:]+:\s*//mg;
-	# delete newlines
-	$result =~ s/\n/ /g;
-	# delete spaces
-	$result =~ s/^\s*|\s*$//g;
+        # delete filenames
+        $result =~ s/^[^:]+:\s*//mg;
 
-	my %qdists = ();
+        # delete newlines
+        $result =~ s/\n/ /g;
 
-	foreach my $qdist (split(/\s+/, $result))
-	{
-	     $qdists{$qdist}++;
-	}
+        # delete spaces
+        $result =~ s/^\s*|\s*$//g;
 
-	ok( (keys %qdists)==1 && exists $qdists{0}, "Tree topology still the same for input tree '$inputfile'");
+        my %qdists = ();
+
+        foreach my $qdist ( split( /\s+/, $result ) ) {
+            $qdists{$qdist}++;
+        }
+
+        ok( ( keys %qdists ) == 1 && exists $qdists{0},
+            "Tree topology still the same for input tree '$inputfile'" );
     }
 }
 

--- a/t/116_AliTV-Tree-_ladderize.t
+++ b/t/116_AliTV-Tree-_ladderize.t
@@ -28,7 +28,7 @@ while (<DATA>)
 foreach my $current_tree (keys %test_set)
 {
    my $obj = new_ok('AliTV::Tree');
-   lives_ok { $obj->file($test_set{$current_tree}{file}) };
+   lives_ok { $obj->file($test_set{$current_tree}{file}) } "Object can be prepared for set '$current_tree'";
 
    $obj->_ladderize();
 

--- a/t/116_AliTV-Tree-_ladderize.t
+++ b/t/116_AliTV-Tree-_ladderize.t
@@ -10,6 +10,36 @@ BEGIN { use_ok('AliTV::Tree') }
 
 can_ok( 'AliTV::Tree', qw(_ladderize) );
 
-my $obj = new_ok('AliTV::Tree');
+# import the test set trees
+my %test_set = ();
+while (<DATA>)
+{
+   chomp($_);
+
+   my ($treename, $input, $expected) = split(/\s+/, $_);
+
+   my ($fh, $fn) = File::Temp::tempfile();
+   print $fh $input;
+
+   $test_set{$treename} = { input => $input, expected => $expected, file => $fn };
+}
+
+# cycle through all test trees and try to ladderize them
+foreach my $current_tree (keys %test_set)
+{
+   my $obj = new_ok('AliTV::Tree');
+   lives_ok { $obj->file($test_set{$current_tree}{file}) };
+
+   $obj->_ladderize();
+
+   # get the tree from the object
+   my $tree = $obj->{_orig_tree};
+   my $tree_newick = $tree->as_text('newick');
+
+   is($tree_newick, $test_set{$current_tree}{expected}, "Got the expected tree for set '$current_tree'");
+}
 
 done_testing;
+
+__DATA__
+TreeA ((b,((d,((g,f),e)),c)),a); (a,(b,(c,(d,(e,(f,g))))));

--- a/t/116_AliTV-Tree-_ladderize.t
+++ b/t/116_AliTV-Tree-_ladderize.t
@@ -8,7 +8,7 @@ use File::Temp;
 
 BEGIN { use_ok('AliTV::Tree') }
 
-can_ok( 'AliTV::Tree', qw(_ladderize) );
+can_ok( 'AliTV::Tree', qw(ladderize _ladderize _order_nodes) );
 
 # import the test set trees
 my %test_set = ();
@@ -16,31 +16,53 @@ while (<DATA>)
 {
    chomp($_);
 
-   my ($treename, $input, $expected) = split(/\s+/, $_);
+   my ($treename, $input, $expected, $expected_down) = split(/\s+/, $_);
 
    my ($fh, $fn) = File::Temp::tempfile();
    print $fh $input;
 
-   $test_set{$treename} = { input => $input, expected => $expected, file => $fn };
+   $test_set{$treename} = { input => $input, expected => $expected, expected_down => $expected_down, file => $fn };
 }
 
 # cycle through all test trees and try to ladderize them
-foreach my $current_tree (keys %test_set)
+foreach my $current_tree (sort keys %test_set)
 {
    my $obj = new_ok('AliTV::Tree');
    lives_ok { $obj->file($test_set{$current_tree}{file}) } "Object can be prepared for set '$current_tree'";
 
-   $obj->_ladderize();
+   $obj->ladderize();
 
    # get the tree from the object
    my $tree = $obj->{_orig_tree};
    my $tree_newick = $tree->as_text('newick');
 
-   is($tree_newick, $test_set{$current_tree}{expected}, "Got the expected tree for set '$current_tree'");
+   is($tree_newick, $test_set{$current_tree}{expected}, "Got the expected tree for set '$current_tree' upward sorted");
+
+   $obj = new_ok('AliTV::Tree');
+   lives_ok { $obj->file($test_set{$current_tree}{file}) } "Object can be prepared for set '$current_tree' II";
+
+   $obj->_ladderize(1);
+
+   # get the tree from the object
+   $tree = $obj->{_orig_tree};
+   $tree_newick = $tree->as_text('newick');
+
+   is($tree_newick, $test_set{$current_tree}{expected}, "Got the expected tree for set '$current_tree' directly upward sorted");
+
+   $obj = new_ok('AliTV::Tree');
+   lives_ok { $obj->file($test_set{$current_tree}{file}) } "Object can be prepared for set '$current_tree' III";
+
+   $obj->_ladderize(0);
+
+   # get the tree from the object
+   $tree = $obj->{_orig_tree};
+   $tree_newick = $tree->as_text('newick');
+
+   is($tree_newick, $test_set{$current_tree}{expected_down}, "Got the expected tree for set '$current_tree' down sorted");
 }
 
 done_testing;
 
 __DATA__
-TreeA ((b,((d,((g,f),e)),c)),a); (a,(b,(c,(d,(e,(f,g))))));
-TreeB ((A,E),((D,(C,(G,H))),(B,F))); ((A,E),((B,F),(D,(C,(G,H)))));
+TreeA ((b,((d,((g,f),e)),c)),a); (a,(b,(c,(d,(e,(f,g)))))); ((((((g,f),e),d),c),b),a);
+TreeB ((A,E),((D,(C,(G,H))),(B,F))); ((A,E),((B,F),(D,(C,(G,H))))); (((((H,G),C),D),(F,B)),(E,A));

--- a/t/116_AliTV-Tree-_ladderize.t
+++ b/t/116_AliTV-Tree-_ladderize.t
@@ -1,0 +1,15 @@
+use strict;
+use warnings;
+
+use Test::More;
+use Test::Exception;
+use File::Which;
+use File::Temp;
+
+BEGIN { use_ok('AliTV::Tree') }
+
+can_ok( 'AliTV::Tree', qw(_ladderize) );
+
+my $obj = new_ok('AliTV::Tree');
+
+done_testing;

--- a/t/116_AliTV-Tree-_ladderize.t
+++ b/t/116_AliTV-Tree-_ladderize.t
@@ -43,3 +43,4 @@ done_testing;
 
 __DATA__
 TreeA ((b,((d,((g,f),e)),c)),a); (a,(b,(c,(d,(e,(f,g))))));
+TreeB ((A,E),((D,(C,(G,H))),(B,F))); ((A,E),((B,F),(D,(C,(G,H)))));

--- a/t/117_AliTV-Tree-get_genome_order.t
+++ b/t/117_AliTV-Tree-get_genome_order.t
@@ -1,0 +1,11 @@
+use strict;
+use warnings;
+
+use Test::More;
+use Test::Exception;
+use File::Which;
+use File::Temp;
+
+BEGIN { use_ok('AliTV::Tree') }
+
+can_ok( 'AliTV::Tree', qw(get_genome_order) );

--- a/t/117_AliTV-Tree-get_genome_order.t
+++ b/t/117_AliTV-Tree-get_genome_order.t
@@ -9,3 +9,38 @@ use File::Temp;
 BEGIN { use_ok('AliTV::Tree') }
 
 can_ok( 'AliTV::Tree', qw(get_genome_order) );
+
+# import the test set trees
+my %test_set = ();
+while (<DATA>)
+{
+   chomp($_);
+
+   my ($treename, $input, $expected) = split(/\s+/, $_);
+
+   my ($fh, $fn) = File::Temp::tempfile();
+   print $fh $input;
+
+   $test_set{$treename} = { input => $input, expected => $expected, file => $fn };
+}
+
+# cycle through all test trees and try to ladderize them
+foreach my $current_tree (sort keys %test_set)
+{
+   my $obj = new_ok('AliTV::Tree');
+   lives_ok { $obj->file($test_set{$current_tree}{file}) } "Object can be prepared for set '$current_tree'";
+
+   $obj->ladderize();
+
+   # get the tree from the object
+   my $tree = join(",", @{$obj->get_genome_order()});
+
+   is($tree, $test_set{$current_tree}{expected}, "Got the expected genome order for set '$current_tree'");
+
+}
+
+done_testing;
+
+__DATA__
+TreeA ((b,((d,((g,f),e)),c)),a); a,b,c,d,e,f,g
+TreeB ((A,E),((D,(C,(G,H))),(B,F))); A,E,B,F,D,C,G,H

--- a/t/510_AliTV-run_working.t
+++ b/t/510_AliTV-run_working.t
@@ -8,10 +8,13 @@ BEGIN { use_ok('AliTV') };
 
 can_ok('AliTV', qw(run));
 
-my $vectorset = 'data/vectors/input.yml';
 my $chloroset = 'data/chloroset/input.yml';
 my $obj = new_ok('AliTV', ["-file" => $chloroset]);
-#my $obj = new_ok('AliTV', ["-file" => $vectorset]);
+
+$obj->run();
+
+my $vectorset = 'data/vectors/input.yml';
+$obj = new_ok('AliTV', ["-file" => $vectorset]);
 
 $obj->run();
 


### PR DESCRIPTION
Added some important improvements concerning the tree handling

1) User provided trees will be ladderized to give a better overview. That ladderized tree will determine the genome order of the output set. Therefore, the tree should always be printed if provided by the user. The AliTV message due to genome orders not fitting to the tree should therefore be avoided.

Moreover, the results of the tree balancing is now checked against the origin tree, if the external program `qdist` is available.

Fixes #88  
Fixes #38 
Fixes #19  
