### PR TITLE
Features formats can be determined by the YML file

### DIFF
--- a/data/chloroset/input.yml
+++ b/data/chloroset/input.yml
@@ -79,3 +79,10 @@ genomes:
       invertedRepeat:
              - data/chloroset/invertedRepeat.tsv
 tree:   data/chloroset/species.tree
+
+features:
+  invertedRepeat:
+    color: "#e7d3e2"
+    form: arrow
+    height: 30
+    visible: 1

--- a/data/chloroset/input.yml
+++ b/data/chloroset/input.yml
@@ -86,3 +86,8 @@ features:
     form: arrow
     height: 30
     visible: 1
+  ndh:
+    color: "#ff006e"
+    form: rect
+    height: 30
+    visible: 1

--- a/data/chloroset/input.yml
+++ b/data/chloroset/input.yml
@@ -91,3 +91,8 @@ features:
     form: rect
     height: 30
     visible: 1
+  ycf:
+    color: "#ffaf00"
+    form: rect
+    height: 30
+    visible: 1

--- a/lib/AliTV.pm
+++ b/lib/AliTV.pm
@@ -217,12 +217,20 @@ sub get_json
     # add all features but links
     foreach my $feat (grep {$_ ne $self->_link_feature_name()} (keys %{$data{data}{features}}))
     {
-	$data{conf}{features}{supportedFeatures}{$feat} = {
-	    color => '#808080',
-	    form => 'rect',
-	    height => 30,
-	    visible => JSON::true
-	};
+	if (exists $self->{_yml_import}{features}{$feat})
+	{
+	    $data{conf}{features}{supportedFeatures}{$feat}{color} = $self->{_yml_import}{features}{$feat}{color};
+	    $data{conf}{features}{supportedFeatures}{$feat}{form} = $self->{_yml_import}{features}{$feat}{form};
+	    $data{conf}{features}{supportedFeatures}{$feat}{height} = $self->{_yml_import}{features}{$feat}{height};
+	    $data{conf}{features}{supportedFeatures}{$feat}{visible} = ($self->{_yml_import}{features}{$feat}{visible}) ? JSON::true : JSON::false;
+	} else {
+	    $data{conf}{features}{supportedFeatures}{$feat} = {
+		color => '#808080',
+		form => 'rect',
+		height => 30,
+		visible => JSON::true
+	    }
+	}
     }
 
     $data{filters} = {

--- a/lib/AliTV/Base/Version.pm
+++ b/lib/AliTV/Base/Version.pm
@@ -4,7 +4,7 @@ use 5.010000;
 #use strict;
 #use warnings;
 
-use version 0.77; our $VERSION = version->declare("v0.1.13");
+use version 0.77; our $VERSION = version->declare("v0.1.14");
 
 # The following code is from Bio::Root::Version module and try to
 # handle multiple levels of inheritance and is adopted to work on


### PR DESCRIPTION
The YAML config file is now capable to set the format of annotated features.

The example chloroplast data set YAML now contains default configuration for 
- inverted repeates
- ndh genes
- ycf genes

fixes #89 
