### PR TITLE
Large sequence sets (default 1 Mbp) are excluded from JSON file for develop

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -44,6 +44,7 @@ t/504_AliTV-file.t
 t/505_AliTV-get_default_settings.t
 t/506_AliTV-project.t
 t/507_AliTV-_write_mapping_file.t
+t/508_AliTV-maximum_seq_length_in_json.t
 t/510_AliTV-run_failing.t
 t/510_AliTV-run_working.t
 t/513_AliTV-_import_genomes.t

--- a/lib/AliTV.pm
+++ b/lib/AliTV.pm
@@ -140,6 +140,16 @@ sub get_json
     my $complete_seq_length = 0;
     foreach (@chromosome_length) { $complete_seq_length += $_; }
 
+    # if the sequence length is longer than (default) 1 Mb, skip all sequence information from the JSON file
+    if ($complete_seq_length > $self->maximum_seq_length_in_json())
+    {
+	$self->_info(sprintf("Number of bases (%d) is longer than the maximum allowed (%d), therefore sequences will be excluded from JSON file", $complete_seq_length, $self->maximum_seq_length_in_json()));
+	foreach (keys %{$chromosomes})
+	{
+	    $chromosomes->{$_}{seq} = "";
+	}
+    }
+
     $data{data}{features} = $features;
     $data{data}{karyo}{chromosomes} = $chromosomes;
 

--- a/lib/AliTV.pm
+++ b/lib/AliTV.pm
@@ -613,6 +613,31 @@ sub _generate_seq_set
     return @{$self->{_seq_set}};
 }
 
+=pod
+
+=head3 C<$obj-E<gt>maximum_seq_length_in_json()>
+
+=head4 I<Parameters>
+
+If one single integer value is provided, it will be used as threshold
+for the maximal sequence length inside the produced JSON file.
+
+=head4 I<Output>
+
+Returns the current value of the maximal sequence length inside the
+produced JSON file.
+
+=head4 I<Description>
+
+B<ATTENTION!!!:>The list always contains the original sequence names, even if the list is not unique for the complete set of all genomes.
+
+=cut
+
+sub maximum_seq_length_in_json
+{
+    my $self = shift;
+}
+
 1;
 
 =pod

--- a/lib/AliTV.pm
+++ b/lib/AliTV.pm
@@ -134,6 +134,12 @@ sub get_json
 	$chromosomes = $genome->get_chromosomes($chromosomes);
     }
 
+    # collect the sequence length of all chromosomes
+    my @chromosome_length = sort { $a <=> $b } map {$chromosomes->{$_}{length}} (keys %{$chromosomes});
+    # calculate the complete sequence length
+    my $complete_seq_length = 0;
+    foreach (@chromosome_length) { $complete_seq_length += $_; }
+
     $data{data}{features} = $features;
     $data{data}{karyo}{chromosomes} = $chromosomes;
 

--- a/lib/AliTV.pm
+++ b/lib/AliTV.pm
@@ -641,7 +641,12 @@ sub maximum_seq_length_in_json
 
     if (@_)
     {
-	$self->{_max_total_seq_length_included_into_json} = shift;
+	my $parameter = shift;
+	unless ($parameter =~ /^\d+$/)
+	{
+	    $self->_logdie("Parameter needs to be an unsigned integer value");
+	}
+	$self->{_max_total_seq_length_included_into_json} = $parameter;
     }
     return $self->{_max_total_seq_length_included_into_json};
 }

--- a/lib/AliTV.pm
+++ b/lib/AliTV.pm
@@ -636,6 +636,8 @@ B<ATTENTION!!!:>The list always contains the original sequence names, even if th
 sub maximum_seq_length_in_json
 {
     my $self = shift;
+
+    return 1000000;
 }
 
 1;

--- a/lib/AliTV.pm
+++ b/lib/AliTV.pm
@@ -32,6 +32,8 @@ sub _initialize
 
     $self->{_links} = {};
 
+    $self->{_max_total_seq_length_included_into_json} = 1000000;
+
     $self->{_links_min_len} = 1000000000; # just a huge value
     $self->{_links_max_len} = 0;          # just a tiny value
     $self->{_links_max_id}  = 0;          # just a zero

--- a/lib/AliTV.pm
+++ b/lib/AliTV.pm
@@ -639,7 +639,11 @@ sub maximum_seq_length_in_json
 {
     my $self = shift;
 
-    return 1000000;
+    if (@_)
+    {
+	$self->{_max_total_seq_length_included_into_json} = shift;
+    }
+    return $self->{_max_total_seq_length_included_into_json};
 }
 
 1;

--- a/lib/AliTV/Base/Version.pm
+++ b/lib/AliTV/Base/Version.pm
@@ -4,7 +4,7 @@ use 5.010000;
 #use strict;
 #use warnings;
 
-use version 0.77; our $VERSION = version->declare("v0.1.15");
+use version 0.77; our $VERSION = version->declare("v0.1.16");
 
 # The following code is from Bio::Root::Version module and try to
 # handle multiple levels of inheritance and is adopted to work on

--- a/t/508_AliTV-maximum_seq_length_in_json.t
+++ b/t/508_AliTV-maximum_seq_length_in_json.t
@@ -10,6 +10,12 @@ can_ok('AliTV', qw(maximum_seq_length_in_json));
 
 my $obj = new_ok('AliTV');
 
+my @forbidden_values = (-1, "A", {}, [], 0.5);
+foreach my $forbidden_value (@forbidden_values)
+{
+	throws_ok { $obj->maximum_seq_length_in_json($forbidden_value); } qr/Parameter needs to be an unsigned integer value/, "Exception if parameter is no unsigned integer value (used '$forbidden_value' for test)";
+}
+
 lives_ok { $obj->maximum_seq_length_in_json(12345); } 'No exception if parameter is an unsigned integer value';
 
 # recreate our object

--- a/t/508_AliTV-maximum_seq_length_in_json.t
+++ b/t/508_AliTV-maximum_seq_length_in_json.t
@@ -2,6 +2,7 @@ use strict;
 use warnings;
 
 use Test::More;
+use Test::Exception;
 
 BEGIN { use_ok('AliTV') };
 

--- a/t/508_AliTV-maximum_seq_length_in_json.t
+++ b/t/508_AliTV-maximum_seq_length_in_json.t
@@ -1,0 +1,10 @@
+use strict;
+use warnings;
+
+use Test::More;
+
+BEGIN { use_ok('AliTV') };
+
+can_ok('AliTV', qw(maximum_seq_length_in_json));
+
+done_testing;

--- a/t/508_AliTV-maximum_seq_length_in_json.t
+++ b/t/508_AliTV-maximum_seq_length_in_json.t
@@ -3,6 +3,8 @@ use warnings;
 
 use Test::More;
 use Test::Exception;
+use JSON;
+use Digest::MD5 qw(md5_hex);
 
 BEGIN { use_ok('AliTV') };
 
@@ -28,4 +30,53 @@ my $new_value = 1234567;
 is($obj->maximum_seq_length_in_json($new_value), $new_value, 'New value will be returned while setting the new value');
 is($obj->maximum_seq_length_in_json(), $new_value, 'New value will be returned after setting a new value');
 
+my $vectorset = 'data/vectors/input.yml';
+
+my $obj_skipped_seqs = new_ok('AliTV', ["-file" => $vectorset]);
+my $seq_skipped_value = 10000;
+$obj_skipped_seqs->maximum_seq_length_in_json($seq_skipped_value);
+my $without_seqs = decode_json($obj_skipped_seqs->run());
+
+my $obj_incl_seqs = new_ok('AliTV', ["-file" => $vectorset]);
+my $seq_incl_value = 100000;
+$obj_incl_seqs->maximum_seq_length_in_json($seq_incl_value);
+my $with_seqs_set = decode_json($obj_incl_seqs->run());
+
+my $obj_default_seqs = new_ok('AliTV', ["-file" => $vectorset]);
+my $with_seqs_default = decode_json($obj_default_seqs->run());
+
+# the m5sums for each input file was determined by
+#
+# for i in data/vectors/*.fasta; do echo "$i:"$(grep -v "^>" "$i" | tr -d "\n" | md5sum | awk '{print $1}'); done | column -tx -s ":"
+# data/vectors/M13mp18.fasta            977004f16cc7cbc9eddeb909d8222592
+# data/vectors/pBluescribeKSPlus.fasta  5497d85208eb4e3108dfe3e263951f4f
+# data/vectors/pBR322.fasta             06f26532a24bff6f3a6d04d70bfdbff3
+# data/vectors/pUC19.fasta              dcaa58eea40748c8ed5417afbd3da5f5
+
+my $md5 = {
+   empty             => md5_hex(""),
+   M13mp18           => "977004f16cc7cbc9eddeb909d8222592",
+   pBluescripeKSPlus => "5497d85208eb4e3108dfe3e263951f4f",
+   pBR322            => "06f26532a24bff6f3a6d04d70bfdbff3",
+   pUC19             => "dcaa58eea40748c8ed5417afbd3da5f5"
+   };
+
+run_test(expected => [$md5->{empty}, $md5->{empty}, $md5->{empty}, $md5->{empty}], test_set_name => "skipped sequences test", json => $without_seqs);
+run_test(expected => [$md5->{M13mp18}, $md5->{pBR322}, $md5->{pBluescripeKSPlus},  $md5->{pUC19}], test_set_name => "skipped sequences test", json => $with_seqs_set);
+run_test(expected => [$md5->{M13mp18}, $md5->{pBR322}, $md5->{pBluescripeKSPlus}, $md5->{pUC19}], test_set_name => "skipped sequences test", json => $with_seqs_default);
+
 done_testing;
+
+sub run_test
+{
+  my %params = @_;
+
+  ok(exists $params{json}{data}, 'Key data exists in returned json for '.$params{test_set_name});
+  ok(exists $params{json}{data}{karyo}, 'Key karyo exists in returned json for '.$params{test_set_name});
+  ok(exists $params{json}{data}{karyo}{chromosomes}, 'Key karyo exists in returned json for '.$params{test_set_name});
+
+  my @got = map {md5_hex($params{json}{data}{karyo}{chromosomes}{$_}{seq})} (sort keys %{$without_seqs->{data}{karyo}{chromosomes}});
+
+  is_deeply(\@got, $params{expected}, "Sequences are as expected for ".$params{test_set_name});
+
+}

--- a/t/508_AliTV-maximum_seq_length_in_json.t
+++ b/t/508_AliTV-maximum_seq_length_in_json.t
@@ -8,4 +8,14 @@ BEGIN { use_ok('AliTV') };
 
 can_ok('AliTV', qw(maximum_seq_length_in_json));
 
+my $obj = new_ok('AliTV');
+
+lives_ok { $obj->maximum_seq_length_in_json(12345); } 'No exception if parameter is an unsigned integer value';
+
+# recreate our object
+$obj = new_ok('AliTV');
+
+my $expected_default = 1000000;
+is($obj->maximum_seq_length_in_json(), $expected_default, 'Default value will be returned');
+
 done_testing;

--- a/t/508_AliTV-maximum_seq_length_in_json.t
+++ b/t/508_AliTV-maximum_seq_length_in_json.t
@@ -18,4 +18,8 @@ $obj = new_ok('AliTV');
 my $expected_default = 1000000;
 is($obj->maximum_seq_length_in_json(), $expected_default, 'Default value will be returned');
 
+my $new_value = 1234567;
+is($obj->maximum_seq_length_in_json($new_value), $new_value, 'New value will be returned while setting the new value');
+is($obj->maximum_seq_length_in_json(), $new_value, 'New value will be returned after setting a new value');
+
 done_testing;


### PR DESCRIPTION
If the total sequences length of the input data set extends 1 Mbp, those sequences won't be included into the output JSON.

The default parameter is 1 Mbp. It can be changed by the method `AliTV::maximum_seq_length_in_json()`.

Fixes #83 
