### PR TITLE
Tick distance will be determined by input data

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -45,6 +45,7 @@ t/505_AliTV-get_default_settings.t
 t/506_AliTV-project.t
 t/507_AliTV-_write_mapping_file.t
 t/508_AliTV-maximum_seq_length_in_json.t
+t/509_AliTV-_calculate_tick_distance.t
 t/510_AliTV-run_failing.t
 t/510_AliTV-run_working.t
 t/513_AliTV-_import_genomes.t

--- a/lib/AliTV.pm
+++ b/lib/AliTV.pm
@@ -728,6 +728,12 @@ number of bases should be a power of ten.
 sub _calculate_tick_distance
 {
     my $self = shift;
+
+    unless (@_ == 1 && ref($_[0]) eq "ARRAY")
+    {
+	$self->_logdie("Need to provide a reference to an array of integers as parameter");
+    }
+
 }
 
 1;

--- a/lib/AliTV.pm
+++ b/lib/AliTV.pm
@@ -695,6 +695,31 @@ sub ticks_every_num_of_bases
 
 =pod
 
+=head3 C<$obj-E<gt>_calculate_tick_distance()>
+
+=head4 I<Parameters>
+
+Requires a reference to a list of sequence length.
+
+=head4 I<Output>
+
+Returns the calculated value
+
+=head4 I<Description>
+
+The value for tick distance is calculated as follows: We want to
+achieve at least 20 ticks in the sequence with the median length. The
+number of bases should be a power of ten.
+
+=cut
+
+sub _calculate_tick_distance
+{
+    my $self = shift;
+}
+
+=pod
+
 =head1 NAME
 
 AliTV - Perl class for the alitv script which generates the JSON input for AliTV

--- a/lib/AliTV.pm
+++ b/lib/AliTV.pm
@@ -647,7 +647,7 @@ produced JSON file.
 
 =head4 I<Description>
 
-B<ATTENTION!!!:>The list always contains the original sequence names, even if the list is not unique for the complete set of all genomes.
+none
 
 =cut
 

--- a/lib/AliTV.pm
+++ b/lib/AliTV.pm
@@ -671,6 +671,30 @@ sub maximum_seq_length_in_json
 
 =pod
 
+=head3 C<$obj-E<gt>ticks_every_num_of_bases()>
+
+=head4 I<Parameters>
+
+If one single integer value is provided, it will be determine how many
+ticks are drawn.
+
+=head4 I<Output>
+
+Returns the current value of the class value.
+
+=head4 I<Description>
+
+none
+
+=cut
+
+sub ticks_every_num_of_bases
+{
+    my $self = shift;
+}
+
+=pod
+
 =head1 NAME
 
 AliTV - Perl class for the alitv script which generates the JSON input for AliTV

--- a/lib/AliTV.pm
+++ b/lib/AliTV.pm
@@ -152,6 +152,10 @@ sub get_json
 	}
     }
 
+    my $tick_distance = $self->_calculate_tick_distance(\@chromosome_length);
+    $self->ticks_every_num_of_bases($tick_distance);
+    $self->_info(sprintf("Ticks will be drawn every %d basepair", $self->ticks_every_num_of_bases()));
+
     $data{data}{features} = $features;
     $data{data}{karyo}{chromosomes} = $chromosomes;
 
@@ -182,7 +186,7 @@ sub get_json
 					'karyoDistance' => 5000,
 					'karyoHeight' => 30,
 					'linkKaryoDistance' => 20,
-					'tickDistance' => 1000,
+					'tickDistance' => $self->ticks_every_num_of_bases(),
 					'tickLabelFrequency' => 10,
 					'treeWidth' => 200
           },

--- a/lib/AliTV.pm
+++ b/lib/AliTV.pm
@@ -734,6 +734,23 @@ sub _calculate_tick_distance
 	$self->_logdie("Need to provide a reference to an array of integers as parameter");
     }
 
+    my $list = shift;
+
+    @{$list} = sort {$a <=> $b} @{$list};
+
+    # calculate the median of the chromosome length
+    my $median_chromosome_length;
+    if (@{$list}%2==0)
+    {
+	$median_chromosome_length = ($list->[@{$list}/2-1]+$list->[@{$list}/2])/2;
+    } else {
+	$median_chromosome_length = $list->[@{$list}/2];
+    }
+    # inside the median chromosome, we want to have at least 20 Ticks, but we want to have a power of 10
+    my $ticks_every_num_of_bases = int(log($median_chromosome_length/20)/log(10));
+    $ticks_every_num_of_bases = 10**$ticks_every_num_of_bases;
+
+    return $ticks_every_num_of_bases;
 }
 
 1;

--- a/lib/AliTV.pm
+++ b/lib/AliTV.pm
@@ -667,8 +667,6 @@ sub maximum_seq_length_in_json
     return $self->{_max_total_seq_length_included_into_json};
 }
 
-1;
-
 =pod
 
 =head3 C<$obj-E<gt>ticks_every_num_of_bases()>
@@ -691,6 +689,18 @@ none
 sub ticks_every_num_of_bases
 {
     my $self = shift;
+
+    if (@_)
+    {
+	my $parameter = shift;
+	unless ($parameter =~ /^\d+$/)
+	{
+	    $self->_logdie("Parameter needs to be an unsigned integer value");
+	}
+	$self->{_ticks_every_num_of_bases} = $parameter;
+    }
+    return $self->{_ticks_every_num_of_bases};
+
 }
 
 =pod
@@ -717,6 +727,8 @@ sub _calculate_tick_distance
 {
     my $self = shift;
 }
+
+1;
 
 =pod
 

--- a/lib/AliTV.pm
+++ b/lib/AliTV.pm
@@ -34,6 +34,8 @@ sub _initialize
 
     $self->{_max_total_seq_length_included_into_json} = 1000000;
 
+    $self->{_ticks_every_num_of_bases} = undef;
+
     $self->{_links_min_len} = 1000000000; # just a huge value
     $self->{_links_max_len} = 0;          # just a tiny value
     $self->{_links_max_id}  = 0;          # just a zero

--- a/lib/AliTV/Base/Version.pm
+++ b/lib/AliTV/Base/Version.pm
@@ -4,7 +4,7 @@ use 5.010000;
 #use strict;
 #use warnings;
 
-use version 0.77; our $VERSION = version->declare("v0.1.16");
+use version 0.77; our $VERSION = version->declare("v0.1.17");
 
 # The following code is from Bio::Root::Version module and try to
 # handle multiple levels of inheritance and is adopted to work on

--- a/t/509_AliTV-_calculate_tick_distance.t
+++ b/t/509_AliTV-_calculate_tick_distance.t
@@ -28,7 +28,7 @@ foreach my $value2set (1000, 5000, 100000)
 
 $obj = new_ok('AliTV');
 
-my @forbidden_values = (-1, "A", {}, 0.5);
+@forbidden_values = (-1, "A", {}, 0.5);
 foreach my $forbidden_value (@forbidden_values)
 {
 	throws_ok { $obj->_calculate_tick_distance($forbidden_value); } qr/Need to provide a reference to an array of integers as parameter/, "Exception if parameter is no reference to an array (used '$forbidden_value' for test)";

--- a/t/509_AliTV-_calculate_tick_distance.t
+++ b/t/509_AliTV-_calculate_tick_distance.t
@@ -34,4 +34,20 @@ foreach my $forbidden_value (@forbidden_values)
 	throws_ok { $obj->_calculate_tick_distance($forbidden_value); } qr/Need to provide a reference to an array of integers as parameter/, "Exception if parameter is no reference to an array (used '$forbidden_value' for test)";
 }
 
+my $sets = {};
+$sets->{setA}{input} = [10000, 10000, 10000];        # median 10000, return should be 100
+$sets->{setB}{input} = [1000, 10000, 100000];        # median 10000, return should be 100
+$sets->{setC}{input} = [1000, 10000, 10000, 100000]; # median 10000, return should be 100
+$sets->{setD}{input} = [100, 1000, 1000, 10000];     # median  1000, return should be 10
+
+$sets->{setA}{expected} = 100;
+$sets->{setB}{expected} = 100;
+$sets->{setC}{expected} = 100;
+$sets->{setD}{expected} = 10;
+
+foreach (sort keys %{$sets})
+{
+   is($obj->_calculate_tick_distance($sets->{$_}{input}), $sets->{$_}{expected}, "Correct return result for input set '$_'");
+}
+
 done_testing;

--- a/t/509_AliTV-_calculate_tick_distance.t
+++ b/t/509_AliTV-_calculate_tick_distance.t
@@ -16,4 +16,14 @@ foreach my $forbidden_value (@forbidden_values)
 	throws_ok { $obj->ticks_every_num_of_bases($forbidden_value); } qr/Parameter needs to be an unsigned integer value/, "Exception if parameter is no unsigned integer value (used '$forbidden_value' for test)";
 }
 
+$obj = new_ok('AliTV');
+
+ok(! defined $obj->ticks_every_num_of_bases(), 'Default value is undef');
+
+foreach my $value2set (1000, 5000, 100000)
+{
+   is($obj->ticks_every_num_of_bases($value2set), $value2set, "Value can be set (value was $value2set)");
+   is($obj->ticks_every_num_of_bases(), $value2set, "Value can be get afterwards (value was $value2set)");
+}
+
 done_testing;

--- a/t/509_AliTV-_calculate_tick_distance.t
+++ b/t/509_AliTV-_calculate_tick_distance.t
@@ -1,0 +1,10 @@
+use strict;
+use warnings;
+
+use Test::More;
+
+BEGIN { use_ok('AliTV') };
+
+can_ok('AliTV', qw(_calculate_tick_distance ticks_every_num_of_bases));
+
+done_testing;

--- a/t/509_AliTV-_calculate_tick_distance.t
+++ b/t/509_AliTV-_calculate_tick_distance.t
@@ -2,9 +2,18 @@ use strict;
 use warnings;
 
 use Test::More;
+use Test::Exception;
 
 BEGIN { use_ok('AliTV') };
 
 can_ok('AliTV', qw(_calculate_tick_distance ticks_every_num_of_bases));
+
+my $obj = new_ok('AliTV');
+
+my @forbidden_values = (-1, "A", {}, [], 0.5);
+foreach my $forbidden_value (@forbidden_values)
+{
+	throws_ok { $obj->ticks_every_num_of_bases($forbidden_value); } qr/Parameter needs to be an unsigned integer value/, "Exception if parameter is no unsigned integer value (used '$forbidden_value' for test)";
+}
 
 done_testing;

--- a/t/509_AliTV-_calculate_tick_distance.t
+++ b/t/509_AliTV-_calculate_tick_distance.t
@@ -26,4 +26,12 @@ foreach my $value2set (1000, 5000, 100000)
    is($obj->ticks_every_num_of_bases(), $value2set, "Value can be get afterwards (value was $value2set)");
 }
 
+$obj = new_ok('AliTV');
+
+my @forbidden_values = (-1, "A", {}, 0.5);
+foreach my $forbidden_value (@forbidden_values)
+{
+	throws_ok { $obj->_calculate_tick_distance($forbidden_value); } qr/Need to provide a reference to an array of integers as parameter/, "Exception if parameter is no reference to an array (used '$forbidden_value' for test)";
+}
+
 done_testing;


### PR DESCRIPTION
The distance between ticks are now determined from the input data set.

The median sequence length of all input sequence data should contain at least 20 ticks and the distance should be a power of 10!

Fixes #39 
