### PR TITLE
Explicitly convert tickDistance to int.

### DIFF
--- a/lib/AliTV.pm
+++ b/lib/AliTV.pm
@@ -705,7 +705,7 @@ sub ticks_every_num_of_bases
 	}
 	$self->{_ticks_every_num_of_bases} = $parameter;
     }
-    return $self->{_ticks_every_num_of_bases};
+    return defined $self->{_ticks_every_num_of_bases} ? int($self->{_ticks_every_num_of_bases}) : undef;
 
 }
 


### PR DESCRIPTION
Check for defined is required as default should be undef.
Conversion of undef to int would fail.
Fix #103
