### PR TITLE
Document lowercase character problem

### DIFF
--- a/bin/alitv.pl
+++ b/bin/alitv.pl
@@ -95,7 +95,8 @@ C<name> key defines the name of the genome and has to be unique.
 =item *
 
 C<sequence_files> key contains a list of sequence files which define
-the sequence(s) of the genome
+the sequence(s) of the genome (beware that lowercase letters in fasta
+files are treated as masked by lastz, see #152 for details)
 
 =item *
 


### PR DESCRIPTION
I added some description to the help text of alitv.pl but the output of this command is also used to create the documentation in `doc/alitv.md`. @greatfireball can you please update this before merging. Or tell me how to do it.