### PR TITLE
Document lowercase character problem

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ cpanm --installdeps .
 
 An article about AliTV has been published in [PeerJ Computer Science](https://peerj.com/articles/cs-116/) [![DOI](https://img.shields.io/badge/DOI-10.7717%2Fpeerj--cs.116-blue.svg)](https://peerj.com/articles/cs-116/)
 Please cite this article if you use AliTV-perl-interface in your project.
-Additionally the software in any specific version can be cited via its zenodo doi, latest:
-[![DOI](https://zenodo.org/badge/41874017.svg)](https://zenodo.org/badge/latestdoi/41874017)
+Additionally the software in any specific version can be cited via its zenodo doi:
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.597916.svg)](https://doi.org/10.5281/zenodo.597916)
 
 ## AUTHOR
 

--- a/bin/alitv.pl
+++ b/bin/alitv.pl
@@ -95,7 +95,8 @@ C<name> key defines the name of the genome and has to be unique.
 =item *
 
 C<sequence_files> key contains a list of sequence files which define
-the sequence(s) of the genome
+the sequence(s) of the genome (beware that lowercase letters in fasta
+files are treated as masked by lastz, see #152 for details)
 
 =item *
 

--- a/bin/alitv.pl
+++ b/bin/alitv.pl
@@ -227,9 +227,9 @@ parameters to call the program for alignment generation.
 
 =head1 CITATION
 
-An article about AliTV has been published in PeerJ Computer Science: https://peerj.com/articles/cs-116/
-Please cite this article if you use AliTV-perl-interface in your project.
-Additionally the software in any specific version can be cited via its zenodo doi: https://zenodo.org/badge/latestdoi/41874017
+An article about AliTV has been published in PeerJ Computer Science: L<https://doi.org/10.7717/peerj-cs.116>
+Please cite this article if you use C<AliTV-perl-interface> in your project.
+Additionally the software in any specific version can be cited via its zenodo doi: L<https://doi.org/10.5281/zenodo.597916>
 
 =head1 AUTHOR
 

--- a/bin/alitv.pl
+++ b/bin/alitv.pl
@@ -96,7 +96,9 @@ C<name> key defines the name of the genome and has to be unique.
 
 C<sequence_files> key contains a list of sequence files which define
 the sequence(s) of the genome (beware that lowercase letters in fasta
-files are treated as masked by lastz, see #152 for details)
+files are treated as masked by lastz, see
+L<issue#152|https://github.com/AliTVTeam/AliTV-perl-interface/issues/152>
+for details)
 
 =item *
 

--- a/doc/alitv.md
+++ b/doc/alitv.md
@@ -177,6 +177,12 @@ parameters to call the program for alignment generation.
            - "--gapped"
            - "--strand=both"
 
+# CITATION
+
+An article about AliTV has been published in PeerJ Computer Science: [https://doi.org/10.7717/peerj-cs.116](https://doi.org/10.7717/peerj-cs.116)
+Please cite this article if you use `AliTV-perl-interface` in your project.
+Additionally the software in any specific version can be cited via its zenodo doi: [https://doi.org/10.5281/zenodo.597916](https://doi.org/10.5281/zenodo.597916)
+
 # AUTHOR
 
 Frank Förster &lt;foersterfrank@gmx.de>

--- a/doc/alitv.md
+++ b/doc/alitv.md
@@ -68,7 +68,10 @@ additionally can have feature definitions.
 
 - `name` key defines the name of the genome and has to be unique.
 - `sequence_files` key contains a list of sequence files which define
-the sequence(s) of the genome
+the sequence(s) of the genome (beware that lowercase letters in fasta
+files are treated as masked by lastz, see
+[issue#152](https://github.com/AliTVTeam/AliTV-perl-interface/issues/152)
+for details)
 - `feature_files` key contains different features. Each is defined as
 a seperate key inside the &lt;feature\_files> and contains a list of files
 describing the features and their locations. In the case of


### PR DESCRIPTION
Original post by @iimog was:
>I added some description to the help text of alitv.pl but the output of this command is also used to create the documentation in doc/alitv.md.

This pull request is based on #154 and will substitute it.

Fix #152 