### PR TITLE
Avoiding rounding issues in JSON filter settings

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -35,6 +35,7 @@ WriteMakefile(
 	Storable => 0,
         Digest::MD5 => 0,
 	FindBin::Real => 0,
+	POSIX => 0,
     }, # e.g., Module::Name => 1.1
     ($] >= 5.005 ?     ## Add these new keywords supported since 5.005
       (ABSTRACT_FROM  => 'lib/AliTV.pm', # retrieve abstract from module

--- a/lib/AliTV.pm
+++ b/lib/AliTV.pm
@@ -268,9 +268,9 @@ sub get_json
                                     },
                          'links' => {
                                       'invisibleLinks' => {},
-                                      'maxLinkIdentity' => $self->{_links_max_id}+0,
+                                      'maxLinkIdentity' => ($self->{_links_max_id} >= 100) ? 100: int($self->{_links_max_id}+1),
                                       'maxLinkLength' => $self->{_links_max_len}+0,
-                                      'minLinkIdentity' => $self->{_links_min_id}+0,
+                                      'minLinkIdentity' => int($self->{_links_min_id}+0),
                                       'minLinkLength' => $self->{_links_min_len}+0
                                     },
                          'onlyShowAdjacentLinks' => JSON::true,

--- a/lib/AliTV.pm
+++ b/lib/AliTV.pm
@@ -6,6 +6,8 @@ use warnings;
 
 use parent 'AliTV::Base';
 
+use POSIX qw(ceil floor);
+
 use YAML;
 use Hash::Merge;
 
@@ -268,9 +270,9 @@ sub get_json
                                     },
                          'links' => {
                                       'invisibleLinks' => {},
-                                      'maxLinkIdentity' => ($self->{_links_max_id} >= 100) ? 100: int($self->{_links_max_id}+1),
+                                      'maxLinkIdentity' => ceil($self->{_links_max_id}),
                                       'maxLinkLength' => $self->{_links_max_len}+0,
-                                      'minLinkIdentity' => int($self->{_links_min_id}+0),
+                                      'minLinkIdentity' => floor($self->{_links_min_id}),
                                       'minLinkLength' => $self->{_links_min_len}+0
                                     },
                          'onlyShowAdjacentLinks' => JSON::true,

--- a/t/303_AliTV-Script-run-with-sequences.t
+++ b/t/303_AliTV-Script-run-with-sequences.t
@@ -462,9 +462,9 @@ __DATA__
     },
     "links": {
       "invisibleLinks": {},
-      "maxLinkIdentity": 99.9482669425763,
+      "maxLinkIdentity": 100,
       "maxLinkLength": 2010,
-      "minLinkIdentity": 65.7084188911704,
+      "minLinkIdentity": 65,
       "minLinkLength": 58
     },
     "onlyShowAdjacentLinks": true,

--- a/t/304_AliTV-Script-run-with-yml.t
+++ b/t/304_AliTV-Script-run-with-yml.t
@@ -425,9 +425,9 @@ __DATA__
     },
     "links": {
       "invisibleLinks": {},
-      "maxLinkIdentity": 99.9482669425763,
+      "maxLinkIdentity": 100,
       "maxLinkLength": 2010,
-      "minLinkIdentity": 65.7084188911704,
+      "minLinkIdentity": 65,
       "minLinkLength": 58
     },
     "onlyShowAdjacentLinks": true,


### PR DESCRIPTION
This version avoids the issues described in #155 and ensures, that the default filter settings inside the produced JSON are integers and include the actual values.

This is ensured by truncating the min value and rounding to the next integer (or 100) for the max value.

Moreover, the version is the base for thev1.0.6 release.

Fix #155 